### PR TITLE
chore: create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,55 @@
+# Borrowed from https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+* @Pakisan @derberg
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+#*.js    @js-owner #This is an inline comment.
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+#*.go docs@example.com
+
+# Teams can be specified as code owners as well. Teams should
+# be identified in the format @org/team-name. Teams must have
+# explicit write access to the repository. In this example,
+# the octocats team in the octo-org organization owns all .txt files.
+#*.txt @octo-org/octocats
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+#/build/logs/ @doctocat
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+#docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+#apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository and any of its
+# subdirectories.
+#/docs/ @doctocat
+
+# In this example, any change inside the `/scripts` directory
+# will require approval from @doctocat or @octocat.
+/scripts/ @doctocat @octocat
+
+# In this example, @octocat owns any file in the `/apps`
+# directory in the root of your repository except for the `/apps/github`
+# subdirectory, as its owners are left empty.
+#/apps/ @octocat
+#/apps/github

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 # review when someone opens a pull request.
 #
 # Note: @philCryoport and @theschles are the same human being.  @philCryoport is his work Github account; @theschles is his personal Github account.
-* @Pakisan @derberg @theschles @philCryoport
+* @Pakisan @asyncapi-bot-eve @theschles @philCryoport
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,9 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @Pakisan @derberg
+#
+# Note: @philCryoport and @theschles are the same human being.  @philCryoport is his work Github account; @theschles is his personal Github account.
+* @Pakisan @derberg @theschles @philCryoport
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
@@ -46,7 +48,7 @@
 
 # In this example, any change inside the `/scripts` directory
 # will require approval from @doctocat or @octocat.
-/scripts/ @doctocat @octocat
+#/scripts/ @doctocat @octocat
 
 # In this example, @octocat owns any file in the `/apps`
 # directory in the root of your repository except for the `/apps/github`


### PR DESCRIPTION
**Description**

@fmvilas suggested [in the AsyncAPI Slack](https://asyncapi.slack.com/archives/CQVJXFNQL/p1673280765233719?thread_ts=1672165038.512309&cid=CQVJXFNQL) to add a `CODEOWNERS` file.  

* I copied the example from Github
* Commented out everything except the important line (global owners) 
* And put in @derberg  and @Pakisan  as they are the code-maintainers