### PR TITLE
chore: support IntelliJ IDEA 2022.2.4 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    id("org.jetbrains.intellij") version "1.9.0"
+    id("org.jetbrains.intellij") version "1.11.0"
     java
-    kotlin("jvm") version "1.6.20"
+    kotlin("jvm") version "1.7.21"
 }
 
 group "com.asyncapi.plugin.idea"
-version = "1.7.1+idea2021"
+version = "1.8.2+idea2022"
 
 repositories {
     mavenCentral()
@@ -21,14 +21,17 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version.set("2022.2.3")
+    version.set("2022.2.4")
     plugins.set(listOf("yaml"))
 }
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
     sinceBuild.set("211")
     untilBuild.set("222.*")
     changeNotes.set("""
-        <p>Fix preview on Windows</p>
+        <p>Support IntelliJ IDEA 2022.2.4</p>
+        <p>Roll Gradle IntelliJ Plugin to current rev (1.11.0)</p>
+        <p>Roll Kotlin JVM to current rev (1.7.21)</p>
+        <p>Roll IntelliJ Plugin Verifier to current rev (1.289)</p>
     """.trimIndent())
 }
 
@@ -54,9 +57,10 @@ tasks.getByName<org.jetbrains.intellij.tasks.RunPluginVerifierTask>("runPluginVe
         "2022.2",
         "2022.2.1",
         "2022.2.2",
-        "2022.2.3"
+        "2022.2.3",
+        "2022.2.4"
     ))
-    verifierVersion.set("1.284")
+    verifierVersion.set("1.289")
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,10 +13,10 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.9.0")
+    testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.9.1")
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
@@ -32,6 +32,8 @@ tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml
         <p>Roll Gradle IntelliJ Plugin to current rev (1.11.0)</p>
         <p>Roll Kotlin JVM to current rev (1.7.21)</p>
         <p>Roll IntelliJ Plugin Verifier to current rev (1.289)</p>
+        <p>Roll jUnit Jupiter to current rev (5.9.1)</p>
+        <p>Roll Kotlin StdLib JDK to current rev (8)</p>
     """.trimIndent())
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group "com.asyncapi.plugin.idea"
-version = "1.8.2+idea2022"
+version = "1.7.2+idea2022"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
# Description

- Support IntelliJ IDEA 2022.2.4
- Roll Gradle IntelliJ Plugin to current rev (1.11.0)
- Roll Kotlin JVM to current rev (1.7.21)
- Roll IntelliJ Plugin Verifier to current rev (1.289)
- Roll jUnit Jupiter to current rev (5.9.1)
- Roll Kotlin StdLib JDK to current rev (8)



# PLEASE note the warnings -- are these OK??




# Built with Temurin 11.0.16.1

<details>
<summary>buildPlugin log</summary>
> Task :patchPluginXml UP-TO-DATE

> Task :verifyPluginConfiguration
[gradle-intellij-plugin :verifyPluginConfiguration] The following plugin configuration issues were found:
- The 'since-build' property is lower than the target IntelliJ Platform major version: 211 < 222.
- The Java configuration specifies sourceCompatibility=11 but IntelliJ Platform 2022.2.4 requires sourceCompatibility=17.
- The dependency on the Kotlin Standard Library (stdlib) is automatically added when using the Gradle Kotlin plugin and may conflict with the version provided with the IntelliJ Platform, see: https://jb.gg/intellij-platform-kotlin-stdlib
See: https://jb.gg/intellij-platform-versions

> Task :compileKotlin UP-TO-DATE
> Task :compileJava NO-SOURCE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :setupInstrumentCode
> Task :instrumentCode UP-TO-DATE
> Task :postInstrumentCode
> Task :classpathIndexCleanup
> Task :jar UP-TO-DATE
> Task :inspectClassesForKotlinIC UP-TO-DATE
> Task :prepareSandbox UP-TO-DATE
> Task :buildSearchableOptions UP-TO-DATE
> Task :jarSearchableOptions UP-TO-DATE
> Task :buildPlugin UP-TO-DATE

BUILD SUCCESSFUL in 2s
14 actionable tasks: 4 executed, 10 up-to-date
</details>

<details>
<summary>runPluginVerifier log</summary>
> Task :patchPluginXml UP-TO-DATE

> Task :verifyPluginConfiguration
[gradle-intellij-plugin :verifyPluginConfiguration] The following plugin configuration issues were found:
- The 'since-build' property is lower than the target IntelliJ Platform major version: 211 < 222.
- The Java configuration specifies sourceCompatibility=11 but IntelliJ Platform 2022.2.4 requires sourceCompatibility=17.
- The dependency on the Kotlin Standard Library (stdlib) is automatically added when using the Gradle Kotlin plugin and may conflict with the version provided with the IntelliJ Platform, see: https://jb.gg/intellij-platform-kotlin-stdlib
See: https://jb.gg/intellij-platform-versions

> Task :compileKotlin UP-TO-DATE
> Task :compileJava NO-SOURCE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :setupInstrumentCode
> Task :instrumentCode UP-TO-DATE
> Task :postInstrumentCode
> Task :classpathIndexCleanup
> Task :jar UP-TO-DATE
> Task :inspectClassesForKotlinIC UP-TO-DATE
> Task :prepareSandbox UP-TO-DATE
> Task :buildSearchableOptions UP-TO-DATE
> Task :jarSearchableOptions UP-TO-DATE
> Task :buildPlugin UP-TO-DATE
> Task :downloadIdeaProductReleasesXml
> Task :listProductsReleases SKIPPED
> Task :verifyPlugin

> Task :runPluginVerifier
Starting the IntelliJ Plugin Verifier 1.289
2023-01-10T11:37:33 [main] INFO  c.j.p.options.OptionsParser - Delete the verification directory /Users/pschlesinger/GitHub/jasyncapi-idea-plugin/build/reports/pluginVerifier because it isn't empty
Verification reports directory: /Users/pschlesinger/GitHub/jasyncapi-idea-plugin/build/reports/pluginVerifier
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by retrofit2.Platform (file:/Users/pschlesinger/.gradle/caches/modules-2/files-2.1/org.jetbrains.intellij.plugins/verifier-cli/1.289/475022f275bcb9cf03e7d609b7dccb22eb1e3805/verifier-cli-1.289-all.jar) to constructor java.lang.invoke.MethodHandles$Lookup(java.lang.Class,int)
WARNING: Please consider reporting this to the maintainers of retrofit2.Platform
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
2023-01-10T11:37:33 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.1
2023-01-10T11:37:33 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.1
2023-01-10T11:37:39 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.1.1
2023-01-10T11:37:39 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.1.1
2023-01-10T11:37:43 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.1.2
2023-01-10T11:37:43 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.1.2
2023-01-10T11:37:47 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.1.3
2023-01-10T11:37:47 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.1.3
2023-01-10T11:37:51 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.2
2023-01-10T11:37:51 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.2
2023-01-10T11:37:54 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.2.1
2023-01-10T11:37:54 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.2.1
2023-01-10T11:37:58 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.2.2
2023-01-10T11:37:58 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.2.2
2023-01-10T11:38:01 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.2.3
2023-01-10T11:38:01 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.2.3
2023-01-10T11:38:04 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.3
2023-01-10T11:38:04 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.3
2023-01-10T11:38:08 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.3.1
2023-01-10T11:38:08 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.3.1
2023-01-10T11:38:13 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.3.2
2023-01-10T11:38:13 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.3.2
2023-01-10T11:38:17 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.3.3
2023-01-10T11:38:17 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2021.3.3
2023-01-10T11:38:21 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.1
2023-01-10T11:38:21 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.1
2023-01-10T11:38:25 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.1.1
2023-01-10T11:38:25 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.1.1
2023-01-10T11:38:29 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.1.2
2023-01-10T11:38:29 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.1.2
2023-01-10T11:38:34 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.1.3
2023-01-10T11:38:34 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.1.3
2023-01-10T11:38:38 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.1.4
2023-01-10T11:38:38 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.1.4
2023-01-10T11:38:43 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.2
2023-01-10T11:38:43 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.2
2023-01-10T11:38:48 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.2.1
2023-01-10T11:38:48 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.2.1
2023-01-10T11:38:53 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.2.2
2023-01-10T11:38:53 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.2.2
2023-01-10T11:38:58 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.2.3
2023-01-10T11:38:58 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.2.3
2023-01-10T11:39:02 [main] INFO  verification - Reading IDE /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.2.4
2023-01-10T11:39:02 [main] INFO  c.j.p.options.OptionsParser - Reading IDE from /Users/pschlesinger/.cache/pluginVerifier/ides/IC-2022.2.4
2023-01-10T11:39:07 [main] INFO  verification - Reading plugin to check from /Users/pschlesinger/GitHub/jasyncapi-idea-plugin/build/distributions/jasyncapi-idea-plugin-1.7.2+idea2022.zip
2023-01-10T11:39:10 [main] INFO  verification - Task check-plugin parameters:
Scheduled verifications (22):
com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-211.6693.111, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-211.7142.45, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-211.7442.40, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-211.7628.21, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-212.4746.92, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-212.5080.55, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-212.5284.40, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-212.5457.46, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-213.5744.223, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-213.6461.79, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-213.6777.52, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-213.7172.25, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-221.5080.210, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-221.5591.52, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-221.5787.30, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-221.5921.22, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-221.6008.13, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-222.3345.118, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-222.3739.54, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-222.4167.29, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-222.4345.14, com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-222.4459.24

2023-01-10T11:39:12 [main] INFO  verification - Finished 1 of 22 verifications (in 2.1 s): IC-212.5457.46 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:12 [main] INFO  verification - Finished 2 of 22 verifications (in 2.1 s): IC-212.5284.40 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:12 [main] INFO  verification - Finished 3 of 22 verifications (in 2.4 s): IC-212.4746.92 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:12 [main] INFO  verification - Finished 4 of 22 verifications (in 2.4 s): IC-212.5080.55 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:13 [main] INFO  verification - Finished 5 of 22 verifications (in 3.4 s): IC-213.6777.52 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:13 [main] INFO  verification - Finished 6 of 22 verifications (in 3.4 s): IC-221.5921.22 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:13 [main] INFO  verification - Finished 7 of 22 verifications (in 3.6 s): IC-213.5744.223 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 8 of 22 verifications (in 3.7 s): IC-221.5787.30 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 9 of 22 verifications (in 3.7 s): IC-211.7142.45 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 10 of 22 verifications (in 3.7 s): IC-213.7172.25 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 11 of 22 verifications (in 3.7 s): IC-213.6461.79 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 12 of 22 verifications (in 3.8 s): IC-221.5591.52 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 13 of 22 verifications (in 3.8 s): IC-211.7442.40 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 14 of 22 verifications (in 3.8 s): IC-211.6693.111 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 15 of 22 verifications (in 3.8 s): IC-211.7628.21 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 16 of 22 verifications (in 3.8 s): IC-221.5080.210 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 17 of 22 verifications (in 1.8 s): IC-221.6008.13 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 18 of 22 verifications (in 1.9 s): IC-222.3345.118 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 19 of 22 verifications (in 1.7 s): IC-222.3739.54 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:14 [main] INFO  verification - Finished 20 of 22 verifications (in 1.8 s): IC-222.4167.29 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:15 [main] INFO  verification - Finished 21 of 22 verifications (in 1.3 s): IC-222.4459.24 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
2023-01-10T11:39:15 [main] INFO  verification - Finished 22 of 22 verifications (in 1.3 s): IC-222.4345.14 against com.asyncapi.plugin.idea:1.7.2+idea2022: Compatible
Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-212.5457.46: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-212.5284.40: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-212.4746.92: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-212.5080.55: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-213.6777.52: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-221.5921.22: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-213.5744.223: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-221.5787.30: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-211.7142.45: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-213.7172.25: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-213.6461.79: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-221.5591.52: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-211.7442.40: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-211.6693.111: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-211.7628.21: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-221.5080.210: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-221.6008.13: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-222.3345.118: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-222.3739.54: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-222.4167.29: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-222.4459.24: Compatible
    Plugin can probably be enabled or disabled without IDE restart

Plugin com.asyncapi.plugin.idea:1.7.2+idea2022 against IC-222.4345.14: Compatible
    Plugin can probably be enabled or disabled without IDE restart

2023-01-10T11:39:15 [main] INFO  verification - Total time spent downloading plugins and their dependencies: 0 ms
2023-01-10T11:39:15 [main] INFO  verification - Total amount of plugins and dependencies downloaded: 0 B
2023-01-10T11:39:15 [main] INFO  verification - Total amount of space used for plugins and dependencies: 0 B

BUILD SUCCESSFUL in 1m 44s
17 actionable tasks: 7 executed, 10 up-to-date

</details>