### PR TITLE
feat: new actions names

### DIFF
--- a/src/main/kotlin/com/asyncapi/plugin/idea/actions/CreateAsyncAPISpecification.kt
+++ b/src/main/kotlin/com/asyncapi/plugin/idea/actions/CreateAsyncAPISpecification.kt
@@ -10,17 +10,17 @@ import com.intellij.psi.PsiDirectory
 /**
  * @author Pavel Bodiachevskii
  */
-class CreateAsyncAPISchema: CreateFileFromTemplateAction(
-        "AsyncAPI schema",
-        "Create a AsyncAPI schema from the specified template",
+class CreateAsyncAPISpecification: CreateFileFromTemplateAction(
+        "AsyncAPI Specification",
+        "Create AsyncAPI specification from the specified template",
         Icons.ASYNCAPI_ICON
 ), DumbAware {
 
     override fun buildDialog(project: Project, directory: PsiDirectory, builder: CreateFileFromTemplateDialog.Builder) {
         builder
                 .setTitle("New API Specification")
-                .addKind("AsyncAPI schema (yaml)", Icons.ASYNCAPI_ICON, "AsyncAPI schema (yaml).yaml")
-                .addKind("AsyncAPI schema (json)", Icons.ASYNCAPI_ICON, "AsyncAPI schema (json).json")
+                .addKind("AsyncAPI 2 (.yaml)", Icons.ASYNCAPI_ICON, "AsyncAPI schema (yaml).yaml")
+                .addKind("AsyncAPI 2 (.json)", Icons.ASYNCAPI_ICON, "AsyncAPI schema (json).json")
     }
 
     override fun getActionName(directory: PsiDirectory?, newName: String, templateName: String?): String {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -61,7 +61,7 @@
 
     <actions>
         <!-- Add your actions here -->
-        <action id="asyncapi.createSchema" class="com.asyncapi.plugin.idea.actions.CreateAsyncAPISchema" text="AsyncAPI Schema" description="Create a AsyncAPI schema">
+        <action id="asyncapi.createSpecification" class="com.asyncapi.plugin.idea.actions.CreateAsyncAPISpecification" text="AsyncAPI Specification" description="Create AsyncAPI specification">
             <add-to-group group-id="NewGroup" relative-to-action="NewFromTemplate" anchor="after"/>
         </action>
     </actions>


### PR DESCRIPTION
- action id: asyncapi.createSchema -> asyncapi.createSpecification
- rename CreateAsyncAPISchema -> CreateAsyncAPISpecification
- replace AsyncAPI Schema -> AsyncAPI Specification
- replace Create a AsyncAPI schema -> Create AsyncAPI specification
- replace AsyncAPI schema (yaml) -> AsyncAPI 2 (.yaml)
- replace AsyncAPI schema (json) -> AsyncAPI 3 (.json)