### PR TITLE
feat: static server should be able to read XSD resources as application/xml

### DIFF
--- a/src/main/kotlin/com/asyncapi/plugin/idea/extensions/web/StaticServer.kt
+++ b/src/main/kotlin/com/asyncapi/plugin/idea/extensions/web/StaticServer.kt
@@ -118,6 +118,10 @@ class StaticServer : HttpRequestHandler() {
             return Resource("application/avro", requestedFile.readBytes())
         }
 
+        if ("xsd" == referenceVirtualFile.extension) {
+            return Resource("application/xml", requestedFile.readBytes())
+        }
+
         if (referenceVirtualFile.fileType !is YAMLFileType && referenceVirtualFile.fileType !is JsonFileType) {
             return null
         }


### PR DESCRIPTION
Fixes #184 

**Description**

- Static Server should be able to read XSD resources as application/xml

**Related issue(s)**
Fixes #184 