### PR TITLE
build: 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 3.3.0+jre21
+published to:
+- [JetBrains marketplace](https://plugins.jetbrains.com/plugin/15673-asyncapi/versions/stable/807396)
+- [GitHub](https://github.com/asyncapi/jasyncapi-idea-plugin/releases/tag/3.3.0%2Bjre21)
+
+### Changed
+
+- Plugin was switched to [freemium model](https://pavelon.dev/posts/asyncapi-jetbrains-plugin-update-freemium/) to ensure sustainable development and faster progress - while keeping all core features free
+
+### Added
+
+- Spectral integration - setup your `.spectralignore` file and lint your specifications in auto or manual mode
+
 ## 3.2.0+jre21
 published to:
 - [JetBrains marketplace](https://plugins.jetbrains.com/plugin/15673-asyncapi/versions/stable/789688)

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -529,3 +529,26 @@ If you want to build the plugin locally and/or install it from this repo — che
 - RustRover — 2024.3+
 - WebStorm — 2024.3+
 - Writerside — 2024.3+
+
+## [3.3.0+jre21](https://github.com/asyncapi/jasyncapi-idea-plugin/releases/tag/3.3.0%2Bjre21)
+
+- Android Studio — Meerkat | 2024.3.1+
+- AppCode — build 243.0+
+- Aqua — 2024.3+
+- CLion — 2024.3+
+- Code With Me Guest — 1.0+
+- DataGrip — 2024.3+
+- DataSpell — 2024.3+
+- GoLand — 2024.3+
+- IntelliJ IDEA Community — 2024.3+
+- IntelliJ IDEA Ultimate — 2024.3+
+- JetBrains Client — 1.0+
+- MPS — 2024.3+
+- PhpStorm — 2024.3+
+- PyCharm — 2024.3+
+- PyCharm Community — 2024.3+
+- Rider — 2024.3+
+- RubyMine — 2024.3+
+- RustRover — 2024.3+
+- WebStorm — 2024.3+
+- Writerside — 2024.3+


### PR DESCRIPTION
- Spectral integration - setup your `.spectralignore` file and lint your specifications in auto or manual mode
- Plugin was switched to [freemium model](https://pavelon.dev/posts/asyncapi-jetbrains-plugin-update-freemium/) to ensure sustainable development and faster progress - while keeping all core features free